### PR TITLE
Forbid tailwind css margin classes

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -740,6 +740,7 @@ const eslintConfig = [
       'tailwindcss/no-contradicting-classname': 'warn',
       'tailwindcss/no-custom-classname': 'warn',
       'tailwindcss/no-unnecessary-arbitrary-value': 'warn',
+      'gitterdun/no-tailwind-margins': 'error',
     },
   },
   {

--- a/packages/eslint-plugin-gitterdun/src/__tests__/noTailwindMargins.test.ts
+++ b/packages/eslint-plugin-gitterdun/src/__tests__/noTailwindMargins.test.ts
@@ -1,0 +1,193 @@
+import {RuleTester} from 'eslint';
+import {noTailwindMargins} from '../noTailwindMargins.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: require('@typescript-eslint/parser'),
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+});
+
+ruleTester.run('no-tailwind-margins', noTailwindMargins, {
+  valid: [
+    // Valid className without margin classes
+    {
+      code: '<div className="flex p-4 bg-blue-500 text-white" />',
+    },
+    {
+      code: '<div className="grid gap-4 space-y-2" />',
+    },
+    {
+      code: '<div className="" />',
+    },
+    {
+      code: '<div className={undefined} />',
+    },
+    // class attribute (for non-React contexts)
+    {
+      code: '<div class="flex p-4 bg-blue-500" />',
+    },
+    // Template literals without margin classes
+    {
+      code: '<div className={`flex p-4 ${isActive ? "bg-blue-500" : "bg-gray-500"}`} />',
+    },
+    // Other attributes should not be checked
+    {
+      code: '<div id="m-4" data-test="mb-2" />',
+    },
+    // String literals that don't look like CSS classes
+    {
+      code: 'const message = "margin-top is not allowed";',
+    },
+    {
+      code: 'const config = "m-4";', // doesn't match Tailwind pattern
+    },
+  ],
+  invalid: [
+    // Single margin class
+    {
+      code: '<div className="flex m-4 p-2" />',
+      errors: [
+        {
+          messageId: 'noMarginClasses',
+          data: {className: 'm-4'},
+        },
+      ],
+    },
+    // Multiple margin classes
+    {
+      code: '<div className="flex m-4 mb-2 p-2" />',
+      errors: [
+        {
+          messageId: 'noMarginClassesMultiple',
+          data: {classNames: 'm-4, mb-2'},
+        },
+      ],
+    },
+    // All margin direction classes
+    {
+      code: '<div className="mt-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'mt-4'}}],
+    },
+    {
+      code: '<div className="mr-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'mr-4'}}],
+    },
+    {
+      code: '<div className="mb-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'mb-4'}}],
+    },
+    {
+      code: '<div className="ml-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'ml-4'}}],
+    },
+    {
+      code: '<div className="mx-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'mx-4'}}],
+    },
+    {
+      code: '<div className="my-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'my-4'}}],
+    },
+    // Negative margin classes
+    {
+      code: '<div className="-m-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-m-4'}}],
+    },
+    {
+      code: '<div className="-mt-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-mt-4'}}],
+    },
+    {
+      code: '<div className="-mr-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-mr-4'}}],
+    },
+    {
+      code: '<div className="-mb-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-mb-4'}}],
+    },
+    {
+      code: '<div className="-ml-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-ml-4'}}],
+    },
+    {
+      code: '<div className="-mx-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-mx-4'}}],
+    },
+    {
+      code: '<div className="-my-4" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: '-my-4'}}],
+    },
+    // Various margin values
+    {
+      code: '<div className="m-0" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-0'}}],
+    },
+    {
+      code: '<div className="m-px" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-px'}}],
+    },
+    {
+      code: '<div className="m-0.5" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-0.5'}}],
+    },
+    {
+      code: '<div className="m-96" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-96'}}],
+    },
+    {
+      code: '<div className="m-auto" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-auto'}}],
+    },
+    // Arbitrary values
+    {
+      code: '<div className="m-[10px]" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-[10px]'}}],
+    },
+    {
+      code: '<div className="mt-[2rem]" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'mt-[2rem]'}}],
+    },
+    // Template literals with margin classes
+    {
+      code: '<div className={`flex m-4 ${isActive ? "bg-blue-500" : "bg-gray-500"}`} />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-4'}}],
+    },
+    {
+      code: '<div className={`flex mt-2 mb-4 ${className}`} />',
+      errors: [{messageId: 'noMarginClassesMultiple', data: {classNames: 'mt-2, mb-4'}}],
+    },
+    // class attribute (for non-React contexts)
+    {
+      code: '<div class="flex m-4 p-2" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-4'}}],
+    },
+    // String literals that look like CSS classes
+    {
+      code: 'const classes = "flex m-4 p-2";',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-4'}}],
+    },
+    {
+      code: 'const buttonClasses = "bg-blue-500 text-white m-2";',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-2'}}],
+    },
+    // Edge case: multiple spaces
+    {
+      code: '<div className="flex    m-4    p-2" />',
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-4'}}],
+    },
+    // Edge case: newlines in className
+    {
+      code: `<div className="flex
+        m-4
+        p-2" />`,
+      errors: [{messageId: 'noMarginClasses', data: {className: 'm-4'}}],
+    },
+  ],
+});

--- a/packages/eslint-plugin-gitterdun/src/index.ts
+++ b/packages/eslint-plugin-gitterdun/src/index.ts
@@ -2,11 +2,13 @@ import type {Rule} from 'eslint';
 import {noMissingI18nMessages} from './noMissingI18nMessages.js';
 import {noExtraI18nMessages} from './noExtraI18nMessages.js';
 import {requireI18nFormatting} from './requireI18nFormatting.js';
+import {noTailwindMargins} from './noTailwindMargins.js';
 
 export const rules = {
   'no-missing-i18n-messages': noMissingI18nMessages,
   'no-extra-i18n-messages': noExtraI18nMessages,
   'require-i18n-formatting': requireI18nFormatting,
+  'no-tailwind-margins': noTailwindMargins,
 } as const satisfies Record<string, Rule.RuleModule>;
 
 const withRules = {rules};

--- a/packages/eslint-plugin-gitterdun/src/noTailwindMargins.ts
+++ b/packages/eslint-plugin-gitterdun/src/noTailwindMargins.ts
@@ -1,0 +1,143 @@
+import type {Rule} from 'eslint';
+import type {Literal} from 'estree';
+
+type JSXAttribute = {
+  type: 'JSXAttribute';
+  name?: {
+    type: 'JSXIdentifier';
+    name: string;
+  };
+  value?: {
+    type: 'Literal' | 'JSXExpressionContainer';
+    value?: string | number | boolean | RegExp | null;
+    expression?: {
+      type: string;
+      quasis?: Array<{
+        value: { raw: string };
+      }>;
+    };
+  };
+};
+
+/**
+ * Detects if a string contains Tailwind CSS margin classes
+ */
+const hasTailwindMarginClasses = (classNameValue: string): string[] => {
+  const marginPrefixes = [
+    'm-', 'mt-', 'mr-', 'mb-', 'ml-', 'mx-', 'my-',
+    '-m-', '-mt-', '-mr-', '-mb-', '-ml-', '-mx-', '-my-'
+  ];
+  
+  const classes = classNameValue.split(/\s+/).filter(Boolean);
+  const violatingClasses: string[] = [];
+  
+  for (const className of classes) {
+    for (const prefix of marginPrefixes) {
+      if (className.startsWith(prefix)) {
+        violatingClasses.push(className);
+        break;
+      }
+    }
+  }
+  
+  return violatingClasses;
+};
+
+export const noTailwindMargins: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow the use of Tailwind CSS margin classes',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+    messages: {
+      noMarginClasses: 'Tailwind CSS margin class "{{className}}" is not allowed. Use padding or gap instead.',
+      noMarginClassesMultiple: 'Tailwind CSS margin classes are not allowed: {{classNames}}. Use padding or gap instead.',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXAttribute(node: JSXAttribute) {
+        // Only check className and class attributes
+        if (!node.name || node.name.type !== 'JSXIdentifier') {
+          return;
+        }
+        
+        const attributeName = node.name.name;
+        if (attributeName !== 'className' && attributeName !== 'class') {
+          return;
+        }
+
+        // Handle string literal values
+        if (node.value && node.value.type === 'Literal') {
+          const literal = node.value as Literal;
+          if (typeof literal.value === 'string') {
+            const violatingClasses = hasTailwindMarginClasses(literal.value);
+            
+            if (violatingClasses.length > 0) {
+              context.report({
+                node,
+                messageId: violatingClasses.length === 1 ? 'noMarginClasses' : 'noMarginClassesMultiple',
+                data: {
+                  className: violatingClasses[0] || '',
+                  classNames: violatingClasses.join(', '),
+                },
+              });
+            }
+          }
+        }
+
+        // Handle template literal expressions (e.g., className={`flex ${someVar}`})
+        if (node.value && node.value.type === 'JSXExpressionContainer') {
+          const expression = node.value.expression;
+          
+          if (expression && expression.type === 'TemplateLiteral' && expression.quasis) {
+            for (const quasi of expression.quasis) {
+              if (quasi.value.raw) {
+                const violatingClasses = hasTailwindMarginClasses(quasi.value.raw);
+                
+                if (violatingClasses.length > 0) {
+                  context.report({
+                    node,
+                    messageId: violatingClasses.length === 1 ? 'noMarginClasses' : 'noMarginClassesMultiple',
+                    data: {
+                      className: violatingClasses[0] || '',
+                      classNames: violatingClasses.join(', '),
+                    },
+                  });
+                }
+              }
+            }
+          }
+        }
+      },
+
+      // Also check regular string literals for non-JSX contexts
+      Literal(node: Literal) {
+        if (typeof node.value === 'string') {
+          // Simple heuristic: if it looks like CSS classes (contains common Tailwind patterns)
+          const value = node.value;
+          const hasTailwindPattern = /\b(flex|grid|text-|bg-|border-|p-|space-)/;
+          
+          if (hasTailwindPattern.test(value)) {
+            const violatingClasses = hasTailwindMarginClasses(value);
+            
+            if (violatingClasses.length > 0) {
+              context.report({
+                node,
+                messageId: violatingClasses.length === 1 ? 'noMarginClasses' : 'noMarginClassesMultiple',
+                data: {
+                  className: violatingClasses[0] || '',
+                  classNames: violatingClasses.join(', '),
+                },
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Add `gitterdun/no-tailwind-margins` ESLint rule to forbid the use of Tailwind CSS margin classes.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7a7963d-5d2d-4c93-8b05-4dc2ea71fdb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c7a7963d-5d2d-4c93-8b05-4dc2ea71fdb0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

