### PR TITLE
Help configure rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -847,6 +847,17 @@ const eslintConfig = [
       'gitterdun/no-extra-i18n-messages': 'off', // enabled later in this file for i18n messages files
       'gitterdun/no-missing-i18n-messages': 'off', // enabled later in this file for i18n messages files
       'gitterdun/require-i18n-formatting': 'off', // enabled later in this file for tsx files
+      'gitterdun/no-unused-data-testid': [
+        'error',
+        {
+          testFileGlobs: [
+            'packages/web/src/**/*.test.ts',
+            'packages/web/src/**/*.test.tsx',
+            'packages/api/src/**/*.test.ts',
+            'packages/e2e/**/*.test.ts',
+          ],
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
Configure `gitterdun/no-unused-data-testid` ESLint rule to identify and remove unused `data-testid` attributes by scanning test files across the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-a18a8124-71b1-4dbe-b931-093950976bcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a18a8124-71b1-4dbe-b931-093950976bcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

